### PR TITLE
Remove extraneous parameter from call to async_add_executor_job

### DIFF
--- a/custom_components/tibber_custom/camera.py
+++ b/custom_components/tibber_custom/camera.py
@@ -203,9 +203,9 @@ class TibberCam(LocalFile):
                 )
 
         try:
-            await self.hass.async_add_executor_job(fig.savefig, self._path, dpi=200)
+            await self.hass.async_add_executor_job(fig.savefig, self._path)
         except Exception:  # noqa: E731
-            _LOGGER.debug("Failed to generate image", exc_info=True)
+            _LOGGER.critical("Failed to generate image", exc_info=True)
 
         plt.close(fig)
         plt.close("all")

--- a/custom_components/tibber_custom/camera.py
+++ b/custom_components/tibber_custom/camera.py
@@ -205,7 +205,7 @@ class TibberCam(LocalFile):
         try:
             await self.hass.async_add_executor_job(fig.savefig, self._path)
         except Exception:  # noqa: E731
-            _LOGGER.critical("Failed to generate image", exc_info=True)
+            _LOGGER.debug("Failed to generate image", exc_info=True)
 
         plt.close(fig)
         plt.close("all")

--- a/custom_components/tibber_custom/manifest.json
+++ b/custom_components/tibber_custom/manifest.json
@@ -7,6 +7,6 @@
   "after_dependencies": ["local_file", "tibber"],
   "codeowners": ["@danielhiversen"],
   "issue_tracker": "https://github.com/Danielhiversen/home_assistant_tibber_custom/issues",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "config_flow": false
 }


### PR DESCRIPTION
This removes `dpi=200` from the call to `async_add_executor_job`. Right
now this code throws an exception as `async_add_executor_job` does not have
a named parameter `dpi`. I am not sure this is fixable so long as
`async_add_executor_job` only implements `*args` and not `**kwargs`.

It should be safe to remove `dpi=200` here since the figure have `dpi=200`
specified on creation.

Also ensure any error messages are displayed by using loglevel critical.

Fixes #14 and #15