### PR TITLE
Fix compatibility with async_camera_image

### DIFF
--- a/custom_components/tibber_custom/camera.py
+++ b/custom_components/tibber_custom/camera.py
@@ -12,6 +12,9 @@ from homeassistant.util import dt as dt_util, slugify
 
 _LOGGER = logging.getLogger(__name__)
 
+DEFAULT_WIDTH = 1200
+DEFAULT_HEIGHT = 700
+
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     Path(hass.config.path("www/")).mkdir(parents=True, exist_ok=True)
@@ -39,12 +42,12 @@ class TibberCam(LocalFile):
 
         super().__init__(self._name, self._path)
 
-    async def async_camera_image(self):
+    async def async_camera_image(self, width=None, height=None):
         """Return bytes of camera image."""
-        await self._generate_fig()
+        await self._generate_fig(width or DEFAULT_WIDTH, height or DEFAULT_HEIGHT)
         return await self.hass.async_add_executor_job(self.camera_image)
 
-    async def _generate_fig(self):
+    async def _generate_fig(self, width, height):
         if (dt_util.now() - self._last_update) < datetime.timedelta(minutes=1):
             return
 
@@ -84,7 +87,7 @@ class TibberCam(LocalFile):
         plt.close("all")
         plt.style.use("ggplot")
         x_fmt = mdates.DateFormatter("%H", tz=tz.gettz("Europe/Berlin"))
-        fig = plt.figure(figsize=(1200 / 200, 700 / 200), dpi=200)
+        fig = plt.figure(figsize=(width / 200, height / 200), dpi=200)
         ax = fig.add_subplot(111)
 
         ax.grid(which="major", axis="x", linestyle="-", color="gray", alpha=0.25)


### PR DESCRIPTION
The method signature for `async_camera_image` has changed, rendering this error and non-working integration:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/aiohttp/web_protocol.py", line 435, in _handle_request
    resp = await request_handler(request)
  File "/usr/local/lib/python3.9/site-packages/aiohttp/web_app.py", line 504, in _handle
    resp = await handler(request)
  File "/usr/local/lib/python3.9/site-packages/aiohttp/web_middlewares.py", line 117, in impl
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/security_filter.py", line 60, in security_filter_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/forwarded.py", line 100, in forwarded_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/request_context.py", line 28, in request_context_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/ban.py", line 79, in ban_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/auth.py", line 220, in auth_middleware
    return await handler(request)
  File "/usr/src/homeassistant/homeassistant/components/http/view.py", line 137, in handle
    result = await result
  File "/usr/src/homeassistant/homeassistant/components/camera/__init__.py", line 741, in get
    return await self.handle(request, camera)
  File "/usr/src/homeassistant/homeassistant/components/camera/__init__.py", line 759, in handle
    image = await _async_get_image(
  File "/usr/src/homeassistant/homeassistant/components/camera/__init__.py", line 179, in _async_get_image
    if image_bytes := await camera.async_camera_image(
TypeError: async_camera_image() got an unexpected keyword argument 'width'
```

This PR fixes that.